### PR TITLE
remove unnecessary build-essential package 🧹

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.13-slim
 
 ENV PYTHONIOENCODING=utf-8
 
-RUN apt-get update && apt-get install -y build-essential
 RUN pip3 install uv
 
 COPY requirements.txt /code/requirements.txt


### PR DESCRIPTION
the resulting docker image goes from 840 to 320 MB 🤯