### PR TITLE
CFT-3505: Add a new dataset - Dining Options

### DIFF
--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -88,12 +88,14 @@
         "options": {
           "enum_titles": [
             "Restaurant Configuration Information",
-            "Orders"
+            "Orders",
+            "Dining Options"
           ]
         },
         "enum": [
           "configuration_information",
-          "orders"
+          "orders",
+          "dining_options"
         ],
         "type": "string"
       },

--- a/flake8.cfg
+++ b/flake8.cfg
@@ -5,6 +5,7 @@ exclude =
     tests,
     example
     venv
+    .venv
 max-line-length = 120
 
 # F812: list comprehension redefines ...

--- a/src/client.py
+++ b/src/client.py
@@ -120,3 +120,18 @@ class ToastClient(HttpClient):
 
         if batch:
             yield batch
+
+    def dining_options(self, restaurant_id: str) -> list[Dict]:
+        """
+        List all dinning options
+        """
+        self.update_auth_header({"Toast-Restaurant-External-ID": restaurant_id})
+
+        try:
+            response = self.request("GET", "config/v2/diningOptions")
+            response.raise_for_status()
+
+        except HTTPError as e:
+            raise UserException(f"Error while getting dining options: {e.response.json()['message']}")
+
+        return response.json()

--- a/src/component.py
+++ b/src/component.py
@@ -82,6 +82,8 @@ class Component(ComponentBase):
                 self.download_restaurant_config(guid)
             if 'orders' in self.cfg.endpoints:
                 self.download_orders(guid)
+            if 'dining_options' in self.cfg.endpoints:
+                self.download_dining_options(guid)
 
         for table, cache_record in self._writer_cache.items():
             cache_record.file.close()
@@ -90,6 +92,17 @@ class Component(ComponentBase):
         state = {'last_run': self.current_start_time}
         self.write_state_file(state)
         logging.debug(f'Writing State file: {state}')
+
+    def download_dining_options(self, restaurant_id: str):
+        dining_options = self.client.dining_options(restaurant_id)
+        mapping = TableMapping.build_from_mapping_dict(self.parser_mapping['dining_options'])
+
+        parser = Parser("dining_options", mapping, False)
+        out = parser.parse_data(dining_options)
+
+        for table_name, table_mapping in table_mappings_flattened_by_key(mapping).items():
+            if table_name in out:
+                self.write_to_csv(out, table_name, table_mapping)
 
     def download_orders(self, restaurant_id: str):
 

--- a/src/parser_mapping.json
+++ b/src/parser_mapping.json
@@ -441,5 +441,21 @@
         "child_tables": {}
       }
     }
+  },
+  "dining_options": {
+    "table_name": "dining_options",
+    "primary_keys": [
+      "guid"
+    ],
+    "column_mappings": {
+      "guid": "guid",
+      "entityType": "entityType",
+      "externalId": "externalId",
+      "name": "name",
+      "behavior": "behavior",
+      "curbside": "curbside"
+    },
+    "force_types": [],
+    "child_tables": {}
   }
 }


### PR DESCRIPTION
## Description

This PR contains code that adds the following things:

- added a new dataset Dining Options
- extended the flake8 tests by including .venv to skip

### Documentation

- [GET /diningOptions](https://doc.toasttab.com/openapi/configuration/operation/diningOptionsGet)

### Testing

- In the endpoints array inside of the configuration, add `dining_options`.
- Run the component and check the data.
- in `data/out/tables` a new file will be created - `dining_options.csv` + related manifest file.
- the primary key is set `guid`.

