### PR TITLE
CFT-3533: extend orders applied discounts

### DIFF
--- a/src/parser_mapping.json
+++ b/src/parser_mapping.json
@@ -352,7 +352,7 @@
             "table_name": "applied_discounts",
             "column_mappings": {
               "guid": "guid",
-              "orders_checks_selections_guid": "orders_checks_selections_guid",
+              "orders_checks_guid": "orders_checks_guid",
               "entityType": "entityType",
               "externalId": "externalId",
               "name": "name",

--- a/src/parser_mapping.json
+++ b/src/parser_mapping.json
@@ -347,6 +347,34 @@
             ],
             "child_tables": {
             }
+          },
+          "appliedDiscounts": {
+            "table_name": "applied_discounts",
+            "column_mappings": {
+              "guid": "guid",
+              "orders_checks_selections_guid": "orders_checks_selections_guid",
+              "entityType": "entityType",
+              "externalId": "externalId",
+              "name": "name",
+              "discountAmount": "discountAmount",
+              "nonTaxDiscountAmount": "nonTaxDiscountAmount",
+              "discount": "discount",
+              "triggers": "triggers",
+              "approver": "approver",
+              "processingState": "processingState",
+              "appliedDiscountReason": "appliedDiscountReason",
+              "loyaltyDetails": "loyaltyDetails",
+              "comboItems": "comboItems",
+              "appliedPromoCode": "appliedPromoCode",
+              "discountType": "discountType",
+              "discountPercent": "discountPercent"
+            },
+            "primary_keys": [
+              "guid"
+            ],
+            "force_types": [
+            ],
+            "child_tables": {}
           }
         }
       }


### PR DESCRIPTION
## Description

This PR contains code that add additional dataset for the `appliedDiscounts` coming from `orders -> checks -> appliedDiscounts`.

The change was made on the mapping level only, with no additional code modification.