### PR TITLE
feat: Extended the menu/order metadata

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -48,6 +48,8 @@ class Component(ComponentBase):
 
         self._init_configuration()
         self._init_client()
+        self._item_group_names: dict[str, str] = {}
+        self._sales_category_names: dict[str, str] = {}
         self.current_start_time = datetime.datetime.now(datetime.UTC).timestamp()
         self.state = self.get_state_file()
 
@@ -80,12 +82,12 @@ class Component(ComponentBase):
         for guid in restaurant_ids:
             if 'configuration_information' in self.cfg.endpoints:
                 self.download_restaurant_config(guid)
+            if 'menus' in self.cfg.endpoints:
+                self.download_menus(guid)
             if 'orders' in self.cfg.endpoints:
                 self.download_orders(guid)
             if 'dining_options' in self.cfg.endpoints:
                 self.download_dining_options(guid)
-            if 'menus' in self.cfg.endpoints:
-                self.download_menus(guid)
 
         for table, cache_record in self._writer_cache.items():
             cache_record.file.close()
@@ -109,9 +111,16 @@ class Component(ComponentBase):
     def download_menus(self, restaurant_id: str):
         menus = self.client.menus(restaurant_id)
         mapping = TableMapping.build_from_mapping_dict(self.parser_mapping['menus'])
-
         parser = Parser("menus", mapping, False)
         out = parser.parse_data(menus)
+
+        for group in out.get("menus_menuGroups", []):
+            if group.get("guid") and group.get("name"):
+                self._item_group_names[group["guid"]] = group["name"]
+
+        for item in out.get("menus_menuGroups_menuItems", []):
+            if item.get("salesCategory_guid") and item.get("salesCategory_name"):
+                self._sales_category_names[item["salesCategory_guid"]] = item["salesCategory_name"]
 
         for table_name, table_mapping in table_mappings_flattened_by_key(mapping).items():
             if table_name in out:
@@ -129,6 +138,10 @@ class Component(ComponentBase):
             out = parser.parse_data(batch)
 
             logging.info(f'Writing {len(out["orders"])} orders to output')
+
+            for record in out.get("orders_checks_selections", []):
+                record["itemGroup_name"] = self._item_group_names.get(record.get("itemGroup_guid"), "")
+                record["salesCategory_name"] = self._sales_category_names.get(record.get("salesCategory_guid"), "")
 
             for table_name, table_mapping in table_mappings_flattened_by_key(mapping).items():
                 if table_name in out:

--- a/src/parser_mapping.json
+++ b/src/parser_mapping.json
@@ -194,7 +194,9 @@
               "receiptLinePrice": "receiptLinePrice",
               "voidReason.guid": "voidReason_guid",
               "voidReason.entityType": "voidReason_entityType",
-              "voidReason.externalId": "voidReason_externalId"
+              "voidReason.externalId": "voidReason_externalId",
+              "itemGroup_name": "itemGroup_name",
+              "salesCategory_name": "salesCategory_name"
             },
             "primary_keys": [
               "guid"


### PR DESCRIPTION
# Enrich selections with itemGroup and salesCategory names

Resolves missing human-readable names on the `selections` table by building in-memory lookup dictionaries from the menus data and injecting them before writing orders to CSV.

## Changes

- `component.py`: Added `_item_group_names` and `_sales_category_names` dicts on `__init__`
- `component.py`: `download_menus` now populates both lookup dicts from `menus_menuGroups` and `menus_menuGroups_menuItems` parsed output
- `component.py`: `download_orders` enriches each record in `orders_checks_selections` with `itemGroup_name` and `salesCategory_name` before writing
- `component.py`: Reordered `run()` to call `download_menus` before `download_orders` so lookups are populated in time
- `parser_mapping.json`: Added `itemGroup_name` and `salesCategory_name` to `selections.column_mappings`

## How to test

1. Configure the component with both `menus` and `orders` in the `endpoints` list
2. Run the component against a restaurant that has orders
3. Open the output `selections.csv` and verify:
   - `itemGroup_name` is populated with the menu group name (e.g. `"Burgers"`) and matches the `itemGroup_guid`
   - `salesCategory_name` is populated (e.g. `"Food"`) and matches the `salesCategory_guid`
   - Cross-reference both values against `menuGroups.csv` and `menuItems.csv` from the same run
4. Verify selections where `itemGroup_guid` or `salesCategory_guid` is empty/null produce empty strings rather than errors
5. Run with multiple restaurants to confirm lookups accumulate correctly across restaurants